### PR TITLE
Button bars are used for glossary, acronyms, and index.  This branch …

### DIFF
--- a/conf/library.conf
+++ b/conf/library.conf
@@ -9,7 +9,7 @@ previous_version   "v0.11"
 directory_path     ".."
 directory_name     "library"
 template_dir       "templates"
-published_dir      "../sml-library-published_buttonTrial"
+published_dir      "../sml-library-published"
 plugins_dir        "plugins"
 images_dir         "files/images"
 

--- a/templates/html/default/document_acronyms_page.tt
+++ b/templates/html/default/document_acronyms_page.tt
@@ -17,10 +17,13 @@ document_id  = document.get_id
 -%]
 [%- page_navigation_block = BLOCK  -%]
 [%- INCLUDE previous_and_next.tt pagename = 'acronyms' -%]
+[%- END -%]
+[%- page_button_block = BLOCK -%]
 [%- INCLUDE acronyms_button_bar.tt -%]
 [%- END -%]
 
-[%- WRAPPER document_page.tt page_navigation = page_navigation_block -%]
+[%- WRAPPER document_page.tt page_navigation = page_navigation_block ,
+                                                                button_bar = page_button_block -%]
 
 <h1 style="text-align:center;">Acronyms</h1>
 

--- a/templates/html/default/document_glossary_page.tt
+++ b/templates/html/default/document_glossary_page.tt
@@ -17,10 +17,13 @@ count       = glossary.get_entry_count
 -%]
 [%- page_navigation_block = BLOCK  -%]
 [%- INCLUDE previous_and_next.tt pagename = 'glossary' -%]
+[%- END -%]
+[%- page_button_block = BLOCK -%]
 [%- INCLUDE glossary_button_bar.tt -%]
 [%- END -%]
 
-[%- WRAPPER document_page.tt page_navigation = page_navigation_block -%]
+[%- WRAPPER document_page.tt page_navigation = page_navigation_block ,
+                                                                button_bar = page_button_block -%]
 
 <h1 style="text-align:center;">Glossary</h1>
 

--- a/templates/html/default/document_index_page.tt
+++ b/templates/html/default/document_index_page.tt
@@ -20,12 +20,14 @@ ontology    = library.get_ontology
 [%- page_navigation_block = BLOCK  -%]
 [%- INCLUDE previous_and_next.tt pagename = 'index' -%]
 [%- END -%]
+[%- page_button_block = BLOCK -%]
+[%- INCLUDE index_button_bar.tt -%]
+[%- END -%]
 
-[%- WRAPPER document_page.tt page_navigation = page_navigation_block -%]
+[%- WRAPPER document_page.tt page_navigation = page_navigation_block ,
+                                                                button_bar = page_button_block -%]
 
 <h1 style="text-align:center;">Index</h1>
-
-[%- INCLUDE index_button_bar.tt -%]
 
 <table width="100%">
 

--- a/templates/html/default/document_page.tt
+++ b/templates/html/default/document_page.tt
@@ -65,6 +65,12 @@ document_id = document.get_id
 </div>
 [%- END -%]
 
+[%- IF button_bar != '' -%]
+<div class="page_navigation">
+[%- button_bar -%]
+</div>
+[%- END -%]
+
 <div class="page_content">
 [%- content -%]
 <div class="pad2"></div>

--- a/templates/html/default/library_acronyms_page.tt
+++ b/templates/html/default/library_acronyms_page.tt
@@ -14,10 +14,14 @@ acronym_list = library.get_acronym_list
 -%]
 
 [%- page_navigation_block = BLOCK  -%]
+[%# future may have nav options to put here-%]
+[%- END -%]
+[%- page_button_block = BLOCK -%]
 [%- INCLUDE acronyms_button_bar.tt -%]
 [%- END -%]
 
-[%- WRAPPER library_page.tt page_navigation = page_navigation_block -%]
+[%- WRAPPER library_page.tt page_navigation = page_navigation_block ,
+                                                                button_bar = page_button_block -%]
 
 <h1 style="text-align:center;">Library Acronyms</h1>
 

--- a/templates/html/default/library_glossary_page.tt
+++ b/templates/html/default/library_glossary_page.tt
@@ -14,10 +14,14 @@ glossary = library.get_glossary
 -%]
 
 [%- page_navigation_block = BLOCK  -%]
+[%# future may have nav options to put here-%]
+[%- END -%]
+[%- page_button_block = BLOCK -%]
 [%- INCLUDE glossary_button_bar.tt -%]
 [%- END -%]
 
-[%- WRAPPER library_page.tt page_navigation = page_navigation_block -%]
+[%- WRAPPER library_page.tt page_navigation = page_navigation_block ,
+                                                                button_bar = page_button_block -%]
 
 <h1 style="text-align:center;">Library Glossary</h1>
 

--- a/templates/html/default/library_index_page.tt
+++ b/templates/html/default/library_index_page.tt
@@ -14,11 +14,17 @@ ps       = library.get_property_store
 ontology = library.get_ontology
 
 -%]
-[%- WRAPPER library_page.tt -%]
+[%- page_navigation_block = BLOCK  -%]
+[%# future may have nav options to put here-%]
+[%- END -%]
+[%- page_button_block = BLOCK -%]
+[%- INCLUDE index_button_bar.tt -%]
+[%- END -%]
+
+[%- WRAPPER library_page.tt page_navigation = page_navigation_block ,
+                                                                button_bar = page_button_block -%]
 
 <h1 style="text-align:center;">Library Index</h1>
-
-[%- INCLUDE index_button_bar.tt -%]
 
 <table>
 

--- a/templates/html/default/library_page.tt
+++ b/templates/html/default/library_page.tt
@@ -51,11 +51,19 @@ library => an SML::Library object
     [%#      INCLUDE xxlibrary_header.tt -%]
     [%#		</div>  %]
     [%#      END -%]
-[%- IF page_navigation != '' -%]
-<div class="page_navigation">
-[%- page_navigation -%]
-</div>
-[%- END -%]
+
+    [%- IF page_navigation != '' -%]
+    <div class="page_navigation">
+    [%- page_navigation -%]
+    </div>
+    [%- END -%]
+    
+    [%- IF button_bar != '' -%]
+    <div class="page_navigation">
+    [%- button_bar -%]
+    </div>
+    [%- END -%]
+
     <div class="page_content">
       [%- content -%]
       <div class="pad2"></div>


### PR DESCRIPTION
…gives the button bar a stationary position at the top of the associated pages.

Yikes! - had to amend the commit because I forgot one file...
